### PR TITLE
Cache fixing

### DIFF
--- a/src/FSharp.Data.Xsd/Xml/XmlProvider.fs
+++ b/src/FSharp.Data.Xsd/Xml/XmlProvider.fs
@@ -100,7 +100,7 @@ type public XmlProvider(cfg:TypeProviderConfig) as this =
         else
             generateType "XML" schema false parseSingleSchema parseListOfSchema getSpecFromSchema 
                 version this cfg bindingContext "" resolutionFolder resource typeName None
-    async { do! Async.Sleep (2*60*1000)
+    async { do! Async.Sleep (10000)
             if cache <> null then cache.TryRemove(typeName) |> ignore } |> Async.Start
     result
    )


### PR DESCRIPTION
I think that the ICache interface creates wrong abstraction level and the user still ends up making multiple request in parallel. So using directly ConcurrentDictionary should be lot better. 

I don't know if Async.Sleep is optimal way to handle timeouts but it is a concept that has been used elsewhere in FSharp.Data code.
