### PR TITLE
Support for importing xsd (common in larger xsds)

### DIFF
--- a/paket-files/fsharp/FSharp.Data/src/CommonProviderImplementation/ConversionsGenerator.fs
+++ b/paket-files/fsharp/FSharp.Data/src/CommonProviderImplementation/ConversionsGenerator.fs
@@ -1,0 +1,75 @@
+﻿// Copyright 2011-2015, Tomas Petricek (http://tomasp.net), Gustavo Guerra (http://functionalflow.co.uk), and other contributors
+// Licensed under the Apache License, Version 2.0, see LICENSE.md in this project
+//
+// Conversions from string to various primitive types
+
+module ProviderImplementation.ConversionsGenerator
+
+open System
+open Microsoft.FSharp.Quotations
+open FSharp.Data.Runtime
+open FSharp.Data.Runtime.StructuralTypes
+open ProviderImplementation
+open ProviderImplementation.ProvidedTypes
+open ProviderImplementation.QuotationBuilder
+
+let getConversionQuotation missingValuesStr cultureStr typ (value:Expr<string option>) =
+  if typ = typeof<string> then <@@ TextRuntime.ConvertString(%value) @@>
+  elif typ = typeof<int> || typ = typeof<Bit0> || typ = typeof<Bit1> then <@@ TextRuntime.ConvertInteger(cultureStr, %value) @@>
+  elif typ = typeof<int64> then <@@ TextRuntime.ConvertInteger64(cultureStr, %value) @@>
+  elif typ = typeof<decimal> then <@@ TextRuntime.ConvertDecimal(cultureStr, %value) @@>
+  elif typ = typeof<float> then <@@ TextRuntime.ConvertFloat(cultureStr, missingValuesStr, %value) @@>
+  elif typ = typeof<bool> || typ = typeof<Bit> then <@@ TextRuntime.ConvertBoolean(%value) @@>
+  elif typ = typeof<DateTime> then <@@ TextRuntime.ConvertDateTime(cultureStr, %value) @@>
+  elif typ = typeof<Guid> then  <@@ TextRuntime.ConvertGuid(%value) @@>
+  else failwith "getConversionQuotation: Unsupported primitive type"
+
+let getBackConversionQuotation missingValuesStr cultureStr typ value : Expr<string> =
+  if typ = typeof<int> || typ = typeof<Bit0> || typ = typeof<Bit1> then <@ TextRuntime.ConvertIntegerBack(cultureStr, %%value) @>
+  elif typ = typeof<int64> then <@ TextRuntime.ConvertInteger64Back(cultureStr, %%value) @>
+  elif typ = typeof<decimal> then <@ TextRuntime.ConvertDecimalBack(cultureStr, %%value) @>
+  elif typ = typeof<float> then <@ TextRuntime.ConvertFloatBack(cultureStr, missingValuesStr, %%value) @>
+  elif typ = typeof<string> then <@ TextRuntime.ConvertStringBack(%%value) @>
+  elif typ = typeof<bool> || typ = typeof<Bit> then <@ TextRuntime.ConvertBooleanBack(%%value, false) @>
+  elif typ = typeof<Guid> then <@ TextRuntime.ConvertGuidBack(%%value) @>
+  elif typ = typeof<DateTime> then <@ TextRuntime.ConvertDateTimeBack(cultureStr, %%value) @>
+  else failwith "getBackConversionQuotation: Unsupported primitive type"
+
+/// Creates a function that takes Expr<string option> and converts it to 
+/// an expression of other type - the type is specified by `field`
+let convertStringValue missingValuesStr cultureStr (field:PrimitiveInferedProperty) = 
+
+  let returnType = 
+    match field.TypeWrapper with
+    | TypeWrapper.None -> field.TypeWithMeasure
+    | TypeWrapper.Option -> typedefof<option<_>>.MakeGenericType field.TypeWithMeasure
+    | TypeWrapper.Nullable -> typedefof<Nullable<_>>.MakeGenericType field.TypeWithMeasure
+
+  let returnTypeWithoutMeasure = 
+    match field.TypeWrapper with
+    | TypeWrapper.None -> field.RuntimeType
+    | TypeWrapper.Option -> typedefof<option<_>>.MakeGenericType field.RuntimeType
+    | TypeWrapper.Nullable -> typedefof<Nullable<_>>.MakeGenericType field.RuntimeType
+
+  let convert (value:Expr<string option>) =
+    let convert value = 
+      getConversionQuotation missingValuesStr cultureStr field.InferedType value
+    match field.TypeWrapper with
+    | TypeWrapper.None ->
+        //prevent value being calculated twice
+        let var = Var("value", typeof<string option>)
+        let varExpr = Expr.Cast<string option> (Expr.Var var)
+        let body = typeof<TextRuntime>?GetNonOptionalValue field.RuntimeType (field.Name, convert varExpr, varExpr)
+        Expr.Let(var, value, body)
+    | TypeWrapper.Option -> convert value
+    | TypeWrapper.Nullable -> typeof<TextRuntime>?OptionToNullable field.RuntimeType (convert value)
+
+  let convertBack value = 
+    let value = 
+      match field.TypeWrapper with
+      | TypeWrapper.None -> ProviderHelpers.some field.RuntimeType value
+      | TypeWrapper.Option -> value
+      | TypeWrapper.Nullable -> typeof<TextRuntime>?NullableToOption field.RuntimeType value
+    getBackConversionQuotation missingValuesStr cultureStr field.InferedType value  :> Expr
+
+  returnType, returnTypeWithoutMeasure, convert, convertBack

--- a/paket-files/fsharp/FSharp.Data/src/CommonProviderImplementation/ConversionsGenerator.fs
+++ b/paket-files/fsharp/FSharp.Data/src/CommonProviderImplementation/ConversionsGenerator.fs
@@ -22,7 +22,9 @@ let getConversionQuotation missingValuesStr cultureStr typ (value:Expr<string op
   elif typ = typeof<bool> || typ = typeof<Bit> then <@@ TextRuntime.ConvertBoolean(%value) @@>
   elif typ = typeof<DateTime> then <@@ TextRuntime.ConvertDateTime(cultureStr, %value) @@>
   elif typ = typeof<Guid> then  <@@ TextRuntime.ConvertGuid(%value) @@>
-  else failwith "getConversionQuotation: Unsupported primitive type"
+  elif typ = typeof<Single> then  <@@ TextRuntime.ConvertSingle(cultureStr, missingValuesStr, %value) @@>
+  else failwith <| sprintf "getConversionQuotation: Unsupported primitive type: %A" typ
+
 
 let getBackConversionQuotation missingValuesStr cultureStr typ value : Expr<string> =
   if typ = typeof<int> || typ = typeof<Bit0> || typ = typeof<Bit1> then <@ TextRuntime.ConvertIntegerBack(cultureStr, %%value) @>
@@ -33,7 +35,8 @@ let getBackConversionQuotation missingValuesStr cultureStr typ value : Expr<stri
   elif typ = typeof<bool> || typ = typeof<Bit> then <@ TextRuntime.ConvertBooleanBack(%%value, false) @>
   elif typ = typeof<Guid> then <@ TextRuntime.ConvertGuidBack(%%value) @>
   elif typ = typeof<DateTime> then <@ TextRuntime.ConvertDateTimeBack(cultureStr, %%value) @>
-  else failwith "getBackConversionQuotation: Unsupported primitive type"
+  elif typ = typeof<Single> then  <@ TextRuntime.ConvertSingleBack(cultureStr, missingValuesStr, %%value) @>
+  else failwith <| sprintf "getConversionQuotation: Unsupported primitive type: %A" typ
 
 /// Creates a function that takes Expr<string option> and converts it to 
 /// an expression of other type - the type is specified by `field`

--- a/paket-files/fsharp/FSharp.Data/src/CommonRuntime/TextConversions.fs
+++ b/paket-files/fsharp/FSharp.Data/src/CommonRuntime/TextConversions.fs
@@ -1,0 +1,123 @@
+﻿// --------------------------------------------------------------------------------------
+// Helper operations for converting converting string values to other types
+// --------------------------------------------------------------------------------------
+
+namespace FSharp.Data
+
+open System
+open System.Globalization
+open System.Text.RegularExpressions
+
+// --------------------------------------------------------------------------------------
+
+[<AutoOpen>]
+module private Helpers =
+
+  /// Convert the result of TryParse to option type
+  let asOption = function true, v -> Some v | _ -> None
+
+  let (|StringEqualsIgnoreCase|_|) (s1:string) s2 = 
+    if s1.Equals(s2, StringComparison.OrdinalIgnoreCase) 
+      then Some () else None
+
+  let (|OneOfIgnoreCase|_|) set str = 
+    if Array.exists (fun s -> StringComparer.OrdinalIgnoreCase.Compare(s, str) = 0) set then Some() else None
+
+  let regexOptions = 
+#if FX_NO_REGEX_COMPILATION
+    RegexOptions.None
+#else
+    RegexOptions.Compiled
+#endif
+  // note on the regex we have /Date()/ and not \/Date()\/ because the \/ escaping 
+  // is already taken care of before AsDateTime is called
+  let msDateRegex = lazy Regex(@"^/Date\((-?\d+)(?:[-+]\d+)?\)/$", regexOptions)
+
+// --------------------------------------------------------------------------------------
+
+/// Conversions from string to string/int/int64/decimal/float/boolean/datetime/guid options
+type TextConversions private() = 
+
+  /// `NaN` `NA` `N/A` `#N/A` `:` `-` `TBA` `TBD`
+  static member val DefaultMissingValues = [| "NaN"; "NA"; "N/A"; "#N/A"; ":"; "-"; "TBA"; "TBD" |]
+  
+  /// `%` `‰` `‱`
+  static member val DefaultNonCurrencyAdorners = [| '%'; '‰'; '‱' |] |> Set.ofArray
+  
+  /// `¤` `$` `¢` `£` `¥` `₱` `﷼` `₤` `₭` `₦` `₨` `₩` `₮` `€` `฿` `₡` `៛` `؋` `₴` `₪` `₫` `₹` `ƒ`
+  static member val DefaultCurrencyAdorners = [| '¤'; '$'; '¢'; '£'; '¥'; '₱'; '﷼'; '₤'; '₭'; '₦'; '₨'; '₩'; '₮'; '€'; '฿'; '₡'; '៛'; '؋'; '₴'; '₪'; '₫'; '₹'; 'ƒ' |] |> Set.ofArray
+
+  static member val private DefaultRemovableAdornerCharacters = 
+    Set.union TextConversions.DefaultNonCurrencyAdorners TextConversions.DefaultCurrencyAdorners
+  
+  //This removes any adorners that might otherwise casue the inference to infer string. A notable a change is
+  //Currency Symbols are now treated as an Adorner like a '%' sign thus are now independant
+  //of the culture. Which is probably better since we have lots of scenarios where we want to
+  //consume values prefixed with € or $ but in a different culture. 
+  static member private RemoveAdorners (value:string) = 
+    String(value.ToCharArray() |> Array.filter (not << TextConversions.DefaultRemovableAdornerCharacters.Contains))
+
+  /// Turns empty or null string value into None, otherwise returns Some
+  static member AsString str =
+    if String.IsNullOrWhiteSpace str then None else Some str
+
+  static member AsInteger cultureInfo text = 
+    Int32.TryParse(TextConversions.RemoveAdorners text, NumberStyles.Integer, cultureInfo) |> asOption
+  
+  static member AsInteger64 cultureInfo text = 
+    Int64.TryParse(TextConversions.RemoveAdorners text, NumberStyles.Integer, cultureInfo) |> asOption
+  
+  static member AsDecimal cultureInfo text =
+    Decimal.TryParse(TextConversions.RemoveAdorners text, NumberStyles.Currency, cultureInfo) |> asOption
+  
+  /// if useNoneForMissingValues is true, NAs are returned as None, otherwise Some Double.NaN is used
+  static member AsFloat missingValues useNoneForMissingValues cultureInfo (text:string) = 
+    match text.Trim() with
+    | OneOfIgnoreCase missingValues -> if useNoneForMissingValues then None else Some Double.NaN
+    | _ -> Double.TryParse(text, NumberStyles.Any, cultureInfo)
+           |> asOption
+           |> Option.bind (fun f -> if useNoneForMissingValues && Double.IsNaN f then None else Some f)
+  
+  static member AsBoolean (text:string) =     
+    match text.Trim() with
+    | StringEqualsIgnoreCase "true" | StringEqualsIgnoreCase "yes" | StringEqualsIgnoreCase "1" -> Some true
+    | StringEqualsIgnoreCase "false" | StringEqualsIgnoreCase "no" | StringEqualsIgnoreCase "0" -> Some false
+    | _ -> None
+
+  /// Parse date time using either the JSON milliseconds format or using ISO 8601
+  /// that is, either `/Date(<msec-since-1/1/1970>)/` or something
+  /// along the lines of `2013-01-28T00:37Z`
+  static member AsDateTime cultureInfo (text:string) =
+    // Try parse "Date(<msec>)" style format
+    let matchesMS = msDateRegex.Value.Match (text.Trim())
+    if matchesMS.Success then
+      matchesMS.Groups.[1].Value 
+      |> Double.Parse 
+      |> DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds 
+      |> Some
+    else
+      // Parse ISO 8601 format, fixing time zone if needed
+      let dateTimeStyles = DateTimeStyles.AllowWhiteSpaces ||| DateTimeStyles.RoundtripKind
+      match DateTime.TryParse(text, cultureInfo, dateTimeStyles) with
+      | true, d ->
+          if d.Kind = DateTimeKind.Unspecified then 
+            new DateTime(d.Ticks, DateTimeKind.Local) |> Some
+          else 
+            Some d
+      | _ -> None
+
+  static member AsGuid (text:string) = 
+    Guid.TryParse(text.Trim()) |> asOption
+
+module internal UnicodeHelper =
+
+    // used http://en.wikipedia.org/wiki/UTF-16#Code_points_U.2B010000_to_U.2B10FFFF as a guide below
+    let getUnicodeSurrogatePair num =
+        // only code points U+010000 to U+10FFFF supported
+        // for coversion to UTF16 surrogate pair
+        let codePoint = num - 0x010000u
+        let HIGH_TEN_BIT_MASK = 0xFFC00u                     // 1111|1111|1100|0000|0000
+        let LOW_TEN_BIT_MASK = 0x003FFu                      // 0000|0000|0011|1111|1111
+        let leadSurrogate = (codePoint &&& HIGH_TEN_BIT_MASK >>> 10) + 0xD800u
+        let trailSurrogate = (codePoint &&& LOW_TEN_BIT_MASK) + 0xDC00u
+        char leadSurrogate, char trailSurrogate

--- a/paket-files/fsharp/FSharp.Data/src/CommonRuntime/TextConversions.fs
+++ b/paket-files/fsharp/FSharp.Data/src/CommonRuntime/TextConversions.fs
@@ -77,7 +77,14 @@ type TextConversions private() =
     | _ -> Double.TryParse(text, NumberStyles.Any, cultureInfo)
            |> asOption
            |> Option.bind (fun f -> if useNoneForMissingValues && Double.IsNaN f then None else Some f)
-  
+
+  static member AsSingle missingValues useNoneForMissingValues cultureInfo (text:string) = 
+    match text.Trim() with
+    | OneOfIgnoreCase missingValues -> if useNoneForMissingValues then None else Some Single.NaN
+    | _ -> Single.TryParse(text, NumberStyles.Any, cultureInfo)
+           |> asOption
+           |> Option.bind (fun f -> if useNoneForMissingValues && Single.IsNaN f then None else Some f)
+
   static member AsBoolean (text:string) =     
     match text.Trim() with
     | StringEqualsIgnoreCase "true" | StringEqualsIgnoreCase "yes" | StringEqualsIgnoreCase "1" -> Some true

--- a/paket-files/fsharp/FSharp.Data/src/CommonRuntime/TextRuntime.fs
+++ b/paket-files/fsharp/FSharp.Data/src/CommonRuntime/TextRuntime.fs
@@ -38,6 +38,11 @@ type TextRuntime =
     text |> Option.bind (TextConversions.AsFloat (TextRuntime.GetMissingValues missingValuesStr)
                                                  (*useNoneForMissingValues*)true 
                                                  (TextRuntime.GetCulture cultureStr))
+   
+  static member ConvertSingle(cultureStr, missingValuesStr, text) = 
+                    text |> Option.bind (TextConversions.AsSingle (TextRuntime.GetMissingValues missingValuesStr)
+                                                                  (*useNoneForMissingValues*)true 
+                                                                  (TextRuntime.GetCulture cultureStr))
 
   static member ConvertBoolean(text) = 
     text |> Option.bind TextConversions.AsBoolean
@@ -72,6 +77,18 @@ type TextRuntime =
     match value with
     | Some value ->
         if Double.IsNaN value then
+          let missingValues = TextRuntime.GetMissingValues missingValuesStr
+          if missingValues.Length = 0 
+          then (TextRuntime.GetCulture cultureStr).NumberFormat.NaNSymbol 
+          else missingValues.[0]
+        else
+          value.ToString(TextRuntime.GetCulture cultureStr)
+    | None -> ""
+
+  static member ConvertSingleBack(cultureStr, missingValuesStr, value:single option) = 
+    match value with
+    | Some value ->
+        if Single.IsNaN value then
           let missingValues = TextRuntime.GetMissingValues missingValuesStr
           if missingValues.Length = 0 
           then (TextRuntime.GetCulture cultureStr).NumberFormat.NaNSymbol 

--- a/paket-files/fsharp/FSharp.Data/src/CommonRuntime/TextRuntime.fs
+++ b/paket-files/fsharp/FSharp.Data/src/CommonRuntime/TextRuntime.fs
@@ -1,0 +1,126 @@
+﻿namespace FSharp.Data.Runtime
+
+open System
+open System.Globalization
+open FSharp.Data
+open FSharp.Data.Runtime
+
+/// Static helper methods called from the generated code for working with text
+type TextRuntime = 
+
+  /// Returns CultureInfo matching the specified culture string
+  /// (or InvariantCulture if the argument is null or empty)
+  static member GetCulture(cultureStr) =
+    if String.IsNullOrWhiteSpace cultureStr 
+    then CultureInfo.InvariantCulture 
+    else CultureInfo cultureStr
+
+  static member GetMissingValues(missingValuesStr) =
+    if String.IsNullOrWhiteSpace missingValuesStr
+    then TextConversions.DefaultMissingValues
+    else missingValuesStr.Split([| ',' |], StringSplitOptions.RemoveEmptyEntries)
+
+  // --------------------------------------------------------------------------------------
+  // string option -> type
+
+  static member ConvertString(text:string option) = text
+
+  static member ConvertInteger(cultureStr, text) = 
+    text |> Option.bind (TextConversions.AsInteger (TextRuntime.GetCulture cultureStr))
+  
+  static member ConvertInteger64(cultureStr, text) = 
+    text |> Option.bind (TextConversions.AsInteger64 (TextRuntime.GetCulture cultureStr))
+
+  static member ConvertDecimal(cultureStr, text) =
+    text |> Option.bind (TextConversions.AsDecimal (TextRuntime.GetCulture cultureStr))
+
+  static member ConvertFloat(cultureStr, missingValuesStr, text) = 
+    text |> Option.bind (TextConversions.AsFloat (TextRuntime.GetMissingValues missingValuesStr)
+                                                 (*useNoneForMissingValues*)true 
+                                                 (TextRuntime.GetCulture cultureStr))
+
+  static member ConvertBoolean(text) = 
+    text |> Option.bind TextConversions.AsBoolean
+
+  static member ConvertDateTime(cultureStr, text) = 
+    text |> Option.bind (TextConversions.AsDateTime (TextRuntime.GetCulture cultureStr))
+
+  static member ConvertGuid(text) = 
+    text |> Option.bind TextConversions.AsGuid
+
+  // --------------------------------------------------------------------------------------
+  // type -> string
+
+  static member ConvertStringBack(value) = defaultArg value ""
+
+  static member ConvertIntegerBack(cultureStr, value:int option) = 
+    match value with
+    | Some value -> value.ToString(TextRuntime.GetCulture cultureStr)
+    | None -> ""
+  
+  static member ConvertInteger64Back(cultureStr, value:int64 option) = 
+    match value with
+    | Some value -> value.ToString(TextRuntime.GetCulture cultureStr)
+    | None -> ""
+  
+  static member ConvertDecimalBack(cultureStr, value:decimal option) = 
+    match value with
+    | Some value -> value.ToString(TextRuntime.GetCulture cultureStr)
+    | None -> ""
+  
+  static member ConvertFloatBack(cultureStr, missingValuesStr, value:float option) = 
+    match value with
+    | Some value ->
+        if Double.IsNaN value then
+          let missingValues = TextRuntime.GetMissingValues missingValuesStr
+          if missingValues.Length = 0 
+          then (TextRuntime.GetCulture cultureStr).NumberFormat.NaNSymbol 
+          else missingValues.[0]
+        else
+          value.ToString(TextRuntime.GetCulture cultureStr)
+    | None -> ""
+  
+  static member ConvertBooleanBack(value:bool option, use0and1) =     
+    match value with
+    | Some value when use0and1 -> if value then "1" else "0"
+    | Some value -> if value then "true" else "false"
+    | None -> ""
+
+  static member ConvertDateTimeBack(cultureStr, value:DateTime option) = 
+    match value with
+    | Some value -> value.ToString("O", TextRuntime.GetCulture cultureStr)
+    | None -> ""
+
+  static member ConvertGuidBack(value:Guid option) = 
+    match value with
+    | Some value -> value.ToString()
+    | None -> ""
+
+  // --------------------------------------------------------------------------------------
+
+  /// Operation that extracts the value from an option and reports a meaningful error message when the value is not there
+  /// For missing strings we return "", and for missing doubles we return NaN
+  /// For other types an error is thrown
+  static member GetNonOptionalValue<'T>(name:string, opt:option<'T>, originalValue) : 'T = 
+    match opt, originalValue with 
+    | Some value, _ -> value
+    | None, _ when typeof<'T> = typeof<string> -> "" |> unbox
+    | None, _ when typeof<'T> = typeof<float> -> Double.NaN |> unbox
+    | None, None -> failwithf "%s is missing" name
+    | None, Some originalValue -> failwithf "Expecting %s in %s, got %s" (typeof<'T>.Name) name originalValue
+
+  /// Turn an F# option type Option<'T> containing a primitive 
+  /// value type into a .NET type Nullable<'T>
+  static member OptionToNullable opt =
+    match opt with 
+    | Some v -> Nullable v
+    | _ -> Nullable()
+
+  /// Turn a .NET type Nullable<'T> to an F# option type Option<'T>
+  static member NullableToOption (nullable:Nullable<_>) =
+    if nullable.HasValue then Some nullable.Value else None
+
+  /// Turn a sync operation into an async operation
+  static member AsyncMap<'T, 'R>(valueAsync:Async<'T>, mapping:Func<'T, 'R>) = 
+    async { let! value = valueAsync in return mapping.Invoke value }
+

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -8,8 +8,6 @@ github fsharp/FSharp.Data src/Net/Http.fs
 
 github fsharp/FSharp.Data src/CommonRuntime/IO.fs
 github fsharp/FSharp.Data src/CommonRuntime/Caching.fs
-github fsharp/FSharp.Data src/CommonRuntime/TextConversions.fs
-github fsharp/FSharp.Data src/CommonRuntime/TextRuntime.fs
 github fsharp/FSharp.Data src/CommonRuntime/Pluralizer.fs
 github fsharp/FSharp.Data src/CommonRuntime/NameUtils.fs
 github fsharp/FSharp.Data src/CommonRuntime/StructuralTypes.fs
@@ -25,7 +23,6 @@ github fsprojects/FSharp.TypeProviders.StarterPack src/ProvidedTypesTesting.fs
 github fsharp/FSharp.Data src/CommonProviderImplementation/QuotationBuilder.fs
 github fsharp/FSharp.Data src/CommonProviderImplementation/AssemblyResolver.fs
 github fsharp/FSharp.Data src/CommonProviderImplementation/Helpers.fs
-github fsharp/FSharp.Data src/CommonProviderImplementation/ConversionsGenerator.fs
 
 github fsharp/FSharp.Data src/Json/JsonValue.fs
 github fsharp/FSharp.Data src/Json/JsonConversions.fs

--- a/tests/FSharp.Data.Xsd.Tests/XsdInferenceTests.fs
+++ b/tests/FSharp.Data.Xsd.Tests/XsdInferenceTests.fs
@@ -321,6 +321,21 @@ let ``elements can reference attribute groups``() =
     let sample1 = """
     <foo myNr="42" available="false" lang="en-US" />"""
     check xsd [| sample1 |]
+
+
+[<Test>]
+let ``can import namespaces``() =
+    let xsd = """
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	    <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd"/>
+        <xs:element name="test">
+		    <xs:complexType>
+			    <xs:attribute ref="xml:base"/>
+		    </xs:complexType>
+	    </xs:element>
+    </xs:schema>"""
+    let inferedTypeFromSchema = getInferedTypeFromSchema xsd
+    printfn "%A" inferedTypeFromSchema
     
 
 


### PR DESCRIPTION
I was attempting to use xsd provider for the [Collada format](https://collada.org/2005/11/COLLADASchema/) and experienced a very annoying issue that it couldn't import correctly.

this isn't the entire fix as there is also an issue with the Single(float32) type not supported by the primitive type generator.

Update: added the commit with the fix for float32